### PR TITLE
WIP catch an edge case for parsing

### DIFF
--- a/code/HTML5Value.php
+++ b/code/HTML5Value.php
@@ -3,7 +3,7 @@
 namespace SilverStripe\HTML5;
 
 use Exception;
-use Masterminds\HTML5;
+use IvoPetkov\HTML5DOMDocument;
 use SilverStripe\View\Parsers\HTMLValue;
 
 class HTML5Value extends HTMLValue
@@ -20,8 +20,9 @@ class HTML5Value extends HTMLValue
 
         // Use HTML5lib to parse the HTML fragment
         try {
-            $parser = new HTML5;
-            $document = $parser->loadHTML(
+            $content = str_replace("\r\n", "\n", $content);
+            $document = new HTML5DOMDocument;
+            $document->loadHTML(
                 '<html><head><meta http-equiv="content-type" content="text/html; charset=utf-8"></head>'.
                 "<body>$content</body></html>"
             );

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "silverstripe/framework": "^4.0",
-        "masterminds/html5": "^2.3"
+        "ivopetkov/html5-dom-document-php": "0.4.16"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/tests/HTML5ValueTest.php
+++ b/tests/HTML5ValueTest.php
@@ -4,6 +4,8 @@ namespace SilverStripe\HTML5\Tests;
 
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\HTML5\HTML5Value;
+use SilverStripe\ORM\FieldType\DBHTMLText;
+use SilverStripe\View\Parsers\ShortcodeParser;
 
 /**
  * @package framework
@@ -71,6 +73,23 @@ class HTML5ValueTest extends SapphireTest
             "<p>paragraph</p>\n<ul><li>1</li>\n</ul>",
             $value->getContent(),
             'Newlines get converted'
+        );
+    }
+
+    public function testShortcodeValue()
+    {
+        ShortcodeParser::get('default')->register(
+            'test_shortcode',
+            function () {
+                return 'bit of test shortcode output';
+            }
+        );
+        $content = DBHTMLText::create('Test', ['shortcodes'=>true])
+            ->setValue('<p>Some content with a [test_shortcode] in it.</p>')
+            ->forTemplate();
+        $this->assertContains(
+            '<p>Some content with a bit of test shortcode output in it.</p>',
+            $content
         );
     }
 }

--- a/tests/HTML5ValueTest.php
+++ b/tests/HTML5ValueTest.php
@@ -85,10 +85,11 @@ class HTML5ValueTest extends SapphireTest
             }
         );
         $content = DBHTMLText::create('Test', ['shortcodes'=>true])
-            ->setValue('<p>Some content with a [test_shortcode] in it.</p>')
+            ->setValue('<p>Some content with a [test_shortcode] and a <br /> followed by an <hr> in it.</p>')
             ->forTemplate();
         $this->assertContains(
-            '<p>Some content with a bit of test shortcode output in it.</p>',
+            // hr is flow content, not phrasing content, so must be corrected to be outside the p tag.
+            '<p>Some content with a bit of test shortcode output and a <br> followed by an </p><hr> in it.',
             $content
         );
     }


### PR DESCRIPTION
At current any field with a Shortcode in it (e.g. [code] ) is translated
as expected into it's replacement content, however thanks to this html5
module it also comes accompanied by a random </img> tag at the end.